### PR TITLE
Fix for termination issue

### DIFF
--- a/scripts/inference/inference_hf.py
+++ b/scripts/inference/inference_hf.py
@@ -191,7 +191,7 @@ if __name__ == '__main__':
                     generation_output = model.generate(
                         input_ids = inputs["input_ids"].to(device),
                         attention_mask = inputs['attention_mask'].to(device),
-                        eos_token_id=tokenizer.eos_token_id,
+                        eos_token_id=terminators,
                         pad_token_id=tokenizer.eos_token_id,
                         generation_config = generation_config
                     )


### PR DESCRIPTION
Pretty sure this is a bug - we have `eos_token_id=terminators` in the block above, and it should be the same in this block. Without this, the generation does not terminate properly.